### PR TITLE
chore: update engine spec in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "gulp-unique-files": "^0.1.2",
     "gulp-useref": "^4.0.0",
     "rename": "^1.0.4"
+  },
+  "engines": {
+    "node": ">=8.10.0 <12.0.0"
   }
 }


### PR DESCRIPTION
Package installation fails with node-gyp building on node versions >= 12.0.0.